### PR TITLE
Standarize and pad with zeroes the filename of the pages

### DIFF
--- a/plugins/mangadex/index.js
+++ b/plugins/mangadex/index.js
@@ -170,8 +170,8 @@ function nextPage() {
 	const filename = atHome.chapter.data[page];
 	if (!filename) return JSON.stringify({});
 
-	//Get the number of 'numbers' of pages
-	const len = Math.ceil(Math.log(atHome.chapter.data.length + 1) / Math.LN10);
+	//Get the number of digits of pages
+	const len = atHome.chapter.data.length.toString().length;
 	//Pad the page number with zeroes depending of the number of pages
 	const pageNum = Array(Math.max(len - String(page + 1).length + 1, 0)).join(0) + (page + 1);
 

--- a/plugins/mangadex/index.js
+++ b/plugins/mangadex/index.js
@@ -167,12 +167,19 @@ function selectChapter(id) {
 function nextPage() {
 	const page = parseInt(mango.storage('page'));
 	const atHome = JSON.parse(mango.storage('atHomeData'));
-	const filename = atHome.chapter.data[page]
-	mango.storage('page', (page + 1).toString());
+	const filename = atHome.chapter.data[page];
 	if (!filename) return JSON.stringify({});
+
+	//Get the number of 'numbers' of pages
+	const len = Math.ceil(Math.log(atHome.chapter.data.length + 1) / Math.LN10);
+	//Pad the page number with zeroes depending of the number of pages
+	const pageNum = Array(Math.max(len - String(page + 1).length + 1, 0)).join(0) + (page + 1);
+
+	const finalFilename = pageNum + '.' + filename.split('.')[filename.split('.').length -1];
+	mango.storage('page', (page + 1).toString());
 
 	return JSON.stringify({
 		url: atHome.baseUrl + '/data/' + atHome.chapter.hash + '/' + filename,
-		filename: filename,
+		filename: finalFilename,
 	});
 }


### PR DESCRIPTION
I've noticed that when creating the manga archive, the filename is taken as-is and, when there are more than nine pages, some software can't order correctly. For example, this chapter:
![imagen](https://user-images.githubusercontent.com/11269785/162005409-969777a9-7771-4f74-94ee-1ad36c3bfc10.png)
So I've made a change where I replace the entire filename with the page number padded with zeroes respecting the extension.
![imagen](https://user-images.githubusercontent.com/11269785/162005768-356a3791-50af-47e7-b098-ee7b76f02646.png)
