### PR TITLE
Fix the search of the Webtoon plugin

### DIFF
--- a/plugins/webtoons/index.js
+++ b/plugins/webtoons/index.js
@@ -22,12 +22,14 @@ function listChapters(query) {
 	if (search["items"].length == 0) mango.raise("Could not find a webtoon with that title.");
 
 	var mangaID;
+	var mangaTitle;
 	for (var i = 0; i < search["items"][0].length; i++) {
 		var item = search["items"][0][i];
 		
 		// Get first webtoon, ignore authors
 		if (item[1][0] == "TITLE") {
 			mangaID = item[3][0];
+			mangaTitle = item[0][0];
 			break;
 		}
 	}
@@ -94,16 +96,9 @@ function listChapters(query) {
 		chapters.push(slimObj);
 	});
 	
-	try {
-		var chapterTitleNode = mango.css(html, 'meta[property="og:title"]');
-		var chapterTitle = mango.attribute(chapterTitleNode[0], "content");
-	} catch (error) {
-		mango.raise("Could not get title.");
-	}
-	
 	return JSON.stringify({
 		chapters: chapters,
-		title: chapterTitle
+		title: mangaTitle
 	});
 }
 


### PR DESCRIPTION
Hello this is my first pull request, sorry if I made any errors, when I search a webtoon with the Webtoons plugin I used to get the following error: 
![Error](https://user-images.githubusercontent.com/37560578/193476542-89bed54f-30fa-47d8-a1c4-1d0ba62e4e82.png)

I made a small change and it should work now